### PR TITLE
Disable livereload.js on github page

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -726,6 +726,10 @@ if ${INPUT_GITBOOK_PDF} || ${INPUT_GITBOOK_EPUB} || ${INPUT_GITBOOK_MOBI} ; then
   fi
 fi
 
+# disable livereload.js
+sed "s/\"livereload\"/\"-livereload\"/" <book.json >tmp && mv -f tmp book.json && cat book.json
+print_info "Disable livereload.js online!"
+
 gitbook build --gitbook=${GITBOOK_BUILD_VERSION}
 if [ $? -eq 0 ]; then
   print_info "Message:gitbook built success"


### PR DESCRIPTION
For testing convenience, people will use the livereload plugin to automatically reload the changes during local testing. It will open a local listening port for communication with the browser. However, this is not necessary and does not work when using github page, and user will get an console error in the browser. To make it easier to use, a small function to automatically block this plugin is added to this action.